### PR TITLE
Updating the deprecated set-output to $GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
         id: store
         run: |
           VERSION='${{ inputs.cumulusci-version }}'
-          echo "::set-output name=cumulusci-version::${VERSION:-3.61.1}"
+          echo "cumulusci-version=${VERSION:-3.61.1}" >> $GITHUB_OUTPUT
           VERSION='${{ inputs.sfdx-version }}'
-          echo "::set-output name=sfdx-version::${VERSION:-7.154}"
+          echo "sfdx-version=${VERSION:-7.154}" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
Github Documentation https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

A test that it worked: 
![image](https://user-images.githubusercontent.com/365521/234399109-ed56d96d-cfec-45d2-8824-ea3a9c3ae5d1.png)
