### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
         id: store
         run: |
           VERSION='${{ inputs.cumulusci-version }}'
-          echo "::set-output name=cumulusci-version::${VERSION:-3.75.1}"
+          echo "cumulusci-version=${VERSION:-3.75.1}" >> $GITHUB_OUTPUT
           VERSION='${{ inputs.sfdx-version }}'
-          echo "::set-output name=sfdx-version::${VERSION:-7.154}"
+          echo "sfdx-version=${VERSION:-7.154}" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
Replace set-output per GitHub warning message:

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

NOTE: I haven't tested this because I don't really know how to but believe the syntax is correct per the docs.