### PR TITLE
Fix deprecated GitHub Actions syntax and update versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
         id: store
         run: |
           VERSION='${{ inputs.cumulusci-version }}'
-          echo "::set-output name=cumulusci-version::${VERSION:-3.75.1}"
+          echo "cumulusci-version=${VERSION:-4.6.0}" >> $GITHUB_OUTPUT
           VERSION='${{ inputs.sfdx-version }}'
-          echo "::set-output name=sfdx-version::${VERSION:-7.154}"
+          echo "sfdx-version=${VERSION:-2.105.6}" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
Updates default package versions and fixes deprecated syntax.

- Update CumulusCI default: 3.75.1 → 4.6.0  
- Update SF CLI default: 7.154 → 2.105.6
- Replace deprecated ::set-output with $GITHUB_OUTPUT